### PR TITLE
[Feat] 공통 가게 정보 컴포넌트 - 공고 상세 카드 추가 & 시급 배지 아이콘 수정

### DIFF
--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -49,7 +49,7 @@ export default function Button({
         buttonVariantClassMap[variant],
         fullWidth && "w-full",
         isDisabled && buttonDisabledClass,
-        className
+        className,
       )}
       {...props}
     >

--- a/src/components/common/button/buttonStyles.ts
+++ b/src/components/common/button/buttonStyles.ts
@@ -1,5 +1,5 @@
 export type ButtonVariant = "primary" | "outline";
-export type ButtonSize = "lg" | "md" ;
+export type ButtonSize = "lg" | "md";
 
 export const buttonBaseClass =
   "inline-flex items-center justify-center gap-2 rounded-md font-bold transition-colors cursor-pointer " +
@@ -12,12 +12,9 @@ export const buttonSizeClassMap: Record<ButtonSize, string> = {
 };
 
 export const buttonVariantClassMap: Record<ButtonVariant, string> = {
-  primary:
-    "bg-orange-600 text-white hover:bg-orange-700 ",
-  outline:
-    "border border-orange-600 bg-white text-orange-600 hover:bg-orange-50 ",
+  primary: "bg-orange-600 text-white hover:bg-orange-700 ",
+  outline: "border border-orange-600 bg-white text-orange-600 hover:bg-orange-50 ",
 };
 
- // disabled 상태는 variant 위에 "덮어쓰기"로 통일 처리
-export const buttonDisabledClass =
-  "bg-gray-400 text-white border-transparent hover:bg-gray-300" ;
+// disabled 상태는 variant 위에 "덮어쓰기"로 통일 처리
+export const buttonDisabledClass = "bg-gray-400 text-white border-transparent hover:bg-gray-300";

--- a/src/components/common/input/Field.tsx
+++ b/src/components/common/input/Field.tsx
@@ -5,7 +5,7 @@ export type FieldProps = {
   label?: string;
   required?: boolean;
   helperText?: string;
-  errorMessage?:string;
+  errorMessage?: string;
   error?: boolean;
   className?: string;
 
@@ -35,7 +35,7 @@ export default function Field({
           className="mb-2 block text-sm font-semibold text-gray-900"
         >
           {label}
-          {required && <span className="ml-0.5 text-red-40]">*</span>}
+          {required && <span className="text-red-40] ml-0.5">*</span>}
         </label>
       )}
 
@@ -44,10 +44,7 @@ export default function Field({
       {(helperText || isError) && (
         <p
           id={helperId}
-          className={cn(
-            "mt-2 text-xs",
-            isError ? "text-red-40" : "text-gray-50"
-          )}
+          className={cn("mt-2 text-xs", isError ? "text-red-40" : "text-gray-50")}
         >
           {isError ? errorMessage : helperText}
         </p>

--- a/src/components/common/input/FieldInput.tsx
+++ b/src/components/common/input/FieldInput.tsx
@@ -9,10 +9,7 @@ type CommonProps = {
   rightSlot?: React.ReactNode;
 };
 
-type InputProps = Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  "size"
-> & {
+type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> & {
   as?: "input";
 };
 
@@ -22,22 +19,8 @@ type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
 
 export type FieldInputProps = CommonProps & (InputProps | TextareaProps);
 
-const FieldInput = React.forwardRef<
-  HTMLInputElement | HTMLTextAreaElement,
-  FieldInputProps
->(
-  (
-    {
-      className,
-      error = false,
-      size = "md",
-      as = "input",
-      rightSlot,
-      id,
-      ...props
-    },
-    ref
-  ) => {
+const FieldInput = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, FieldInputProps>(
+  ({ className, error = false, size = "md", as = "input", rightSlot, id, ...props }, ref) => {
     const autoId = React.useId();
     const inputId = id ?? autoId;
     const isTextarea = as === "textarea";
@@ -52,7 +35,7 @@ const FieldInput = React.forwardRef<
         : "border-gray-30 focus:border-gray-40 focus:ring-gray-20",
       props.disabled && "cursor-not-allowed bg-gray-10 text-gray-50",
       !isTextarea && rightSlot && "pr-12",
-      className
+      className,
     );
 
     return (
@@ -83,7 +66,7 @@ const FieldInput = React.forwardRef<
         )}
       </div>
     );
-  }
+  },
 );
 
 FieldInput.displayName = "FieldInput";

--- a/src/components/common/input/PasswordInput.tsx
+++ b/src/components/common/input/PasswordInput.tsx
@@ -15,7 +15,7 @@ export type PasswordInputProps = Omit<
 };
 
 const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
-  ({ className, error = false, allowToggle = true, size="md", id, ...props }, ref) => {
+  ({ className, error = false, allowToggle = true, size = "md", id, ...props }, ref) => {
     const autoId = React.useId();
     const inputId = id ?? autoId;
     const [visible, setVisible] = React.useState(false);
@@ -35,9 +35,9 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
             error
               ? "border-red-500 focus:ring-red-200"
               : "border-gray-30 focus:border-gray-40 focus:ring-gray-20",
-            props.disabled && "cursor-not-allowed bg-gray-10 text-gray-50",
+            props.disabled && "bg-gray-10 cursor-not-allowed text-gray-50",
             allowToggle && "pr-16",
-            className
+            className,
           )}
           {...props}
         />
@@ -55,7 +55,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
         )}
       </div>
     );
-  }
+  },
 );
 
 PasswordInput.displayName = "PasswordInput";

--- a/src/components/common/input/Select.tsx
+++ b/src/components/common/input/Select.tsx
@@ -52,9 +52,9 @@ export default function Select({
           error
             ? "border-red-500 focus:ring-red-200"
             : "border-gray-30 focus:border-gray-40 focus:ring-gray-20",
-          disabled && "cursor-not-allowed bg-gray-10",
+          disabled && "bg-gray-10 cursor-not-allowed",
           "text-gray-900, data-placeholder:text-gray-40",
-          className
+          className,
         )}
         aria-invalid={error || undefined}
       >
@@ -85,23 +85,24 @@ export default function Select({
           position="popper"
           sideOffset={8}
           className={cn(
-            "z-50 min-w-(--radix-select-trigger-width) overflow-hidden rounded-md border border-gray-300 bg-white shadow-md"
+            "z-50 min-w-(--radix-select-trigger-width) overflow-hidden rounded-md border border-gray-300 bg-white shadow-md",
           )}
         >
-          <SelectPrimitive.Viewport 
-          className={cn(
-              "p-1 max-h-47.5 overflow-y-auto",   // ✅ 기본값: 5개 정도 보이게
-              viewportClassName
-            )}>
+          <SelectPrimitive.Viewport
+            className={cn(
+              "max-h-47.5 overflow-y-auto p-1", // ✅ 기본값: 5개 정도 보이게
+              viewportClassName,
+            )}
+          >
             {options.map((opt) => (
               <SelectPrimitive.Item
                 key={opt.value}
                 value={opt.value}
                 disabled={opt.disabled}
                 className={cn(
-                  "relative flex cursor-pointer select-none items-center rounded-sm px-4 py-2 text-sm outline-none",
+                  "relative flex cursor-pointer items-center rounded-sm px-4 py-2 text-sm outline-none select-none",
                   "data-highlighted:bg-gray-100",
-                  "data-disabled:cursor-not-allowed data-disabled:opacity-50"
+                  "data-disabled:cursor-not-allowed data-disabled:opacity-50",
                 )}
               >
                 <SelectPrimitive.ItemText>{opt.label}</SelectPrimitive.ItemText>

--- a/src/components/common/shop-info/ShopInfoCard.tsx
+++ b/src/components/common/shop-info/ShopInfoCard.tsx
@@ -7,29 +7,29 @@ type Badge = {
 };
 
 type DetailCard = {
-  title?: string;      // 기본 "공고 설명"
-  content: string;     // 회색 카드 내용
-  className?: string;  // 필요시 커스텀
+  title?: string; // 기본 "공고 설명"
+  content: string; // 회색 카드 내용
+  className?: string; // 필요시 커스텀
 };
 
 type NoticeVariantProps = {
   variant: "notice";
-  wageLabel?: string;            // "시급"
-  wageText: string;              // "15,000원"
-  wageBadge?: Badge;             // "기존 시급보다 50% ↑"
-  scheduleText?: string;         // "2023-01-02 15:00~18:00 (3시간)"
-  address: string;               // "서울시 송파구"
+  wageLabel?: string; // "시급"
+  wageText: string; // "15,000원"
+  wageBadge?: Badge; // "기존 시급보다 50% ↑"
+  scheduleText?: string; // "2023-01-02 15:00~18:00 (3시간)"
+  address: string; // "서울시 송파구"
   description: string;
-  footer: ReactNode;             // 보통 버튼 1개
+  footer: ReactNode; // 보통 버튼 1개
 };
 
 type ShopVariantProps = {
   variant: "shop";
-  categoryLabel?: string;        // "식당"
-  title: string;                 // "도토리 식당"
+  categoryLabel?: string; // "식당"
+  title: string; // "도토리 식당"
   address: string;
   description: string;
-  footer: ReactNode;             // 보통 버튼 2개
+  footer: ReactNode; // 보통 버튼 2개
 };
 
 type CommonProps = {
@@ -50,10 +50,10 @@ export default function ShopInfoCard(props: ShopInfoCardProps) {
     <div className="flex flex-col gap-4">
       <section
         className={[
-          "flex flex-col w-full rounded-2xl",
-          "h-112.5 md:h-169.25 p-4 gap-4",
-          "md:p-6 md:gap-6",
-          "lg:flex-row lg:w-241 lg:h-89 lg:p-6 lg:gap-8",
+          "flex w-full flex-col rounded-2xl",
+          "h-112.5 gap-4 p-4 md:h-169.25",
+          "md:gap-6 md:p-6",
+          "lg:h-89 lg:w-241 lg:flex-row lg:gap-8 lg:p-6",
           props.variant === "shop" ? "bg-[#FDE9E4]" : "bg-white",
           className ?? "",
         ].join(" ")}
@@ -64,7 +64,7 @@ export default function ShopInfoCard(props: ShopInfoCardProps) {
           className={[
             "relative w-full overflow-hidden rounded-2xl bg-neutral-100",
             "h-44.5 md:h-76.75",
-            "lg:w-134.75 lg:h-77",
+            "lg:h-77 lg:w-134.75",
           ].join(" ")}
         >
           <Image
@@ -78,11 +78,7 @@ export default function ShopInfoCard(props: ShopInfoCardProps) {
 
         {/* content */}
         <div className="flex flex-1 flex-col">
-          {props.variant === "notice" ? (
-            <NoticeContent {...props} />
-          ) : (
-            <ShopContent {...props} />
-          )}
+          {props.variant === "notice" ? <NoticeContent {...props} /> : <ShopContent {...props} />}
         </div>
       </section>
 
@@ -110,17 +106,15 @@ function DetailCardView({
   return (
     <div
       className={[
-        "mt-4 w-full rounded-2xl bg-gray-10",
+        "bg-gray-10 mt-4 w-full rounded-2xl",
         "px-6 py-5 md:px-8 md:py-6",
         className ?? "",
       ].join(" ")}
       aria-label="공고 설명"
     >
-      <h4 className="text-sm md:text-base font-extrabold text-neutral-900">
-        {title}
-      </h4>
+      <h4 className="text-sm font-extrabold text-neutral-900 md:text-base">{title}</h4>
 
-      <p className="mt-2 text-sm md:text-base leading-relaxed text-neutral-700 whitespace-pre-line">
+      <p className="mt-2 text-sm leading-relaxed whitespace-pre-line text-neutral-700 md:text-base">
         {content}
       </p>
     </div>
@@ -138,12 +132,10 @@ function NoticeContent({
 }: Omit<NoticeVariantProps, "variant">) {
   return (
     <>
-      <p className="mt-1 text-base md:text-lg font-extrabold text-orange-600">
-        {wageLabel}
-      </p>
+      <p className="mt-1 text-base font-extrabold text-orange-600 md:text-lg">{wageLabel}</p>
 
       <div className="flex items-center gap-3">
-        <p className="text-2xl md:text-[28px] font-extrabold tracking-tight text-neutral-900">
+        <p className="text-2xl font-extrabold tracking-tight text-neutral-900 md:text-[28px]">
           {wageText}
         </p>
 
@@ -151,27 +143,35 @@ function NoticeContent({
           <span className="inline-flex items-center rounded-full bg-orange-600 px-3 py-1.5 text-sm font-extrabold text-white">
             {wageBadge.text}
 
-            {wageBadge.icon ? (
-              <span className="shrink-0">{wageBadge.icon}</span>
-            ) : null}
+            {wageBadge.icon ? <span className="shrink-0">{wageBadge.icon}</span> : null}
           </span>
         )}
       </div>
 
       {scheduleText && (
-        <div className="mt-1 md:mt-2 flex items-center gap-2 text-neutral-500">
-          <Image src="/icon/clock.svg" alt="근무 시간" width={20} height={20} />
+        <div className="mt-1 flex items-center gap-2 text-neutral-500 md:mt-2">
+          <Image
+            src="/icon/clock.svg"
+            alt="근무 시간"
+            width={20}
+            height={20}
+          />
           <span className="text-sm md:text-base">{scheduleText}</span>
         </div>
       )}
 
-      <div className="mt-1 md:mt-2 flex items-center gap-2 text-neutral-500">
-        <Image src="/icon/location.svg" alt="근무 지역" width={20} height={20} />
-        <span className="text-sm md:text-base font-normal">{address}</span>
+      <div className="mt-1 flex items-center gap-2 text-neutral-500 md:mt-2">
+        <Image
+          src="/icon/location.svg"
+          alt="근무 지역"
+          width={20}
+          height={20}
+        />
+        <span className="text-sm font-normal md:text-base">{address}</span>
       </div>
 
-      <div className="mt-2 md:mt-3 flex-1 overflow-hidden">
-        <p className="text-sm md:text-base leading-relaxed text-neutral-800 line-clamp-3 whitespace-pre-line">
+      <div className="mt-2 flex-1 overflow-hidden md:mt-3">
+        <p className="line-clamp-3 text-sm leading-relaxed whitespace-pre-line text-neutral-800 md:text-base">
           {description}
         </p>
       </div>
@@ -190,24 +190,22 @@ function ShopContent({
 }: Omit<ShopVariantProps, "variant">) {
   return (
     <>
-      <p className="mt-1 text-base md:text-lg font-bold text-orange-600">{categoryLabel}</p>
+      <p className="mt-1 text-base font-bold text-orange-600 md:text-lg">{categoryLabel}</p>
 
-      <h3 className="mt-2 text-xl md:text-[28px] font-extrabold text-neutral-900">
-        {title}
-      </h3>
+      <h3 className="mt-2 text-xl font-extrabold text-neutral-900 md:text-[28px]">{title}</h3>
 
-      <div className="mt-1 md:mt-2 flex items-center gap-2 text-neutral-500">
+      <div className="mt-1 flex items-center gap-2 text-neutral-500 md:mt-2">
         <Image
           src="/icon/pin.svg"
           alt="근무 지역"
           width={20}
           height={20}
         />
-        <span className="text-sm md:text-base font-normal">{address}</span>
+        <span className="text-sm font-normal md:text-base">{address}</span>
       </div>
 
-      <div className="mt-3 md:mt-4 flex-1 overflow-hidden">
-        <p className="text-sm md:text-base leading-relaxed text-neutral-800 line-clamp-5 whitespace-pre-line">
+      <div className="mt-3 flex-1 overflow-hidden md:mt-4">
+        <p className="line-clamp-5 text-sm leading-relaxed whitespace-pre-line text-neutral-800 md:text-base">
           {description}
         </p>
       </div>
@@ -216,5 +214,3 @@ function ShopContent({
     </>
   );
 }
-
-


### PR DESCRIPTION
## 작업 내용
<!-- 구현하거나 수정한 내용을 상세히 적어주세요. -->
1. 공고 설명 회색 카드 옵션 추가
 `detail` prop이 있을 때만 하단에 렌더링

2. 시급 배지에 아이콘 슬롯 추가
  아이콘 렌더링할 자리 추가
  ```
<ShopInfoCard
      variant="notice"
      imageUrl="/images/shop.jpg"
      imageAlt="가게 대표 이미지"
      wageLabel="시급"
      wageText="15,000원"
      wageBadge={{
          text: "기존 시급보다 50%",
          icon: <Image src="/icon/arrowfff.svg" alt="" width={12} height={12} />,
      }}
      scheduleText="2023.01.02 15:00~18:00 (3시간)"
      address="서울시 송파구"
      description={`알바하기 편한 너구리네 라면집!\n라면 올려두고 끓이기만 하면 되어서 쉬운 편에 속하는 가게입니다.`}
      footer={
         <Button variant="primary" size="lg" fullWidth>
            신청하기
          </Button>
      }
      detail={{ content: "기존 알바 친구가 그만둬서...기존 알바 친구가 그만둬서...기존 알바 친구가 그만둬서...기존 알바 친구가 그만둬서...기존 알바 친구가 그만둬서...기존 알바 친구가 그만둬서...기존 알바 친구가 그만둬서...기존 알바 친구가 그만둬서..." }}
        />
```

<br>

## 관련 이슈
<!-- 관련된 이슈 번호를 기입해주세요. -->
- close #

<br>

## 체크리스트
<!-- PR을 올리기 전 아래 항목들을 확인해주세요. -->
- [x] 코드에 불필요한 콘솔 로그가 없습니다.
- [x] 코드 스타일이 ESLint & Prettier 규칙을 따릅니다.
- [x] 빌드 및 실행 테스트를 완료했습니다.

<br>

## 스크린샷
<!-- UI 변경 사항이 있을 경우 첨부해주세요. -->
<img width="991" height="554" alt="스크린샷 2026-01-02 12 30 28" src="https://github.com/user-attachments/assets/3f76afec-d2ec-4bb8-aaa8-609f16b3137f" />
